### PR TITLE
🐛 Ensure all .lua matching matches at end of filename only

### DIFF
--- a/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/init.lua
+++ b/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/init.lua
@@ -2174,7 +2174,7 @@ function AMM:SetupCustomEntities()
 	local files = dir("./Collabs/Custom Entities")
 	if #files > 0 then
 	  	for _, mod in ipairs(files) do
-	    	if string.find(mod.name, '.lua') then
+	    	if string.find(mod.name, '.lua$') then
 				local data = require("Collabs/Custom Entities/"..mod.name)
 				local modder = data.modder
 				local uid = data.unique_identifier
@@ -2259,7 +2259,7 @@ function AMM:SetupCustomProps()
 	local files = dir("./Collabs/Custom Props")
 	if #files > 0 then
 	  	for _, mod in ipairs(files) do
-	    	if string.find(mod.name, '.lua') then
+	    	if string.find(mod.name, '.lua$') then
 				local data = require("Collabs/Custom Props/"..mod.name)
 				local modder = data.modder
 				local uid = data.unique_identifier
@@ -2313,7 +2313,7 @@ function AMM:SetupCollabAppearances()
 	local files = dir("./Collabs")
 	if #files > 0 then
 		for _, mod in ipairs(files) do
-			if string.find(mod.name, '.lua') and mod.name ~= "API.lua" then
+			if string.find(mod.name, '.lua$') and mod.name ~= "API.lua" then
 				os.rename("./Collabs/"..mod.name, "./Collabs/Custom Appearances/"..mod.name)
 			end
 		end
@@ -2323,7 +2323,7 @@ function AMM:SetupCollabAppearances()
 	local collabs = {}
 	if #files > 0 then
 	  	for _, mod in ipairs(files) do
-	    	if string.find(mod.name, '.lua') then
+	    	if string.find(mod.name, '.lua$') then
 				local collab = require("Collabs/Custom Appearances/"..mod.name)
 				local metadata = collab.metadata
 


### PR DESCRIPTION
This was at least one of the causes for the incorrect "player in menu" errors; it would match `.lua` anywhere so e.g. `API.lua.vortex_backup` was attempted to be `require`d, which errored out the state.

The reason the backup file was in the wrong place to begin with seems to be the code that moved old-style locations to `Custom Appearances/`.

Closes #14 