### PR TITLE
Fix companion sometimes entering driver seat

### DIFF
--- a/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/Modules/scan.lua
+++ b/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/Modules/scan.lua
@@ -776,7 +776,7 @@ function Scan:AutoAssignSeats()
         end
       elseif counter <= seatsNumber then
         if Scan.selectedSeats[ent.name] == nil then
-          Scan.selectedSeats[ent.name] = {name = ent.name, entity = ent.handle, seat = Scan.vehicleSeats[counter], vehicle = Scan.vehicle}
+          Scan.selectedSeats[ent.name] = {name = ent.name, entity = ent.handle, seat = Scan.vehicleSeats[counter+1], vehicle = Scan.vehicle}
         end
       elseif counter > seatsNumber then
         table.insert(Scan.leftBehind, { ent = ent.handle, cmd = Util:HoldPosition(ent.handle, 99999) })


### PR DESCRIPTION
Scan.vehicleSeat takes its values from the following snippet of scan.lua
```
    for _, seat in ipairs(Scan.possibleSeats) do
      if Game['VehicleComponent::HasSlot;GameInstanceVehicleObjectCName'](vehicle, CName.new(seat.cname)) then
        table.insert(Scan.vehicleSeats, seat)
      end
    end
```

In turn, Scan.possibleSeats is initialized thus
```
  Scan.possibleSeats = {
    { name = AMM.LocalizableString("Seat_FrontLeft"), cname = "seat_front_left", enum = 0},
    { name = AMM.LocalizableString("Seat_FrontRight"), cname = "seat_front_right", enum = 1},
    { name = AMM.LocalizableString("Seat_BackLeft"), cname = "seat_back_left", enum = 2},
    { name = AMM.LocalizableString("Seat_BackRight"), cname = "seat_back_right", enum = 3},
  }
```

The variable  `counter` being initialized at 1, accounting for lua table indexes starting at 1, in current version it defaults to the first value of the table (`seat_front_left`)   
Because this blocks is entered under condition of `counter <= seatsNumber`, we're sure table index will not be OOB