### PR TITLE
Add preset favorites

### DIFF
--- a/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/Modules/props.lua
+++ b/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/Modules/props.lua
@@ -78,6 +78,7 @@ function Props:new()
 
   -- Main Properties
   Props.presets = {}
+  Props.favoritePresets = {}
   Props.entities = {}
   Props.spawnedPropsList = {}
   Props.spawnedProps = {}
@@ -677,6 +678,16 @@ function Props:DrawPresetConfig()
     ImGui.SetTooltip(AMM.LocalizableString("Warn_PresetsFolder_Info"))
   end
 
+  ImGui.SameLine()
+
+  local favLabel = AMM.LocalizableString("Label_Favorite")
+  if Props:IsFavoritePreset(Props.selectedPreset.file_name) then
+    favLabel = AMM.LocalizableString("Label_Unfavorite")
+  end
+  if ImGui.SmallButton(favLabel .. "##PresetFavorite") then
+    Props:ToggleFavoritePreset(Props.selectedPreset)
+    Props.presets = Props:LoadPresets()
+  end
   ImGui.SameLine()
 
   if ImGui.SmallButton(AMM.LocalizableString("Button_Refresh")) then
@@ -2215,10 +2226,37 @@ function Props:LoadPresets()
         table.insert(presets, {file_name = file.name, name = name, props = props, lights = lights, frames = frames})
       end
     end
+
+    table.sort(presets, function(a, b)
+      local favA = Props:IsFavoritePreset(a.file_name)
+      local favB = Props:IsFavoritePreset(b.file_name)
+      if favA ~= favB then return favA end
+      return a.name:lower() < b.name:lower()
+    end)
+
     return presets
   else
     return Props.presets
   end
+end
+
+function Props:IsFavoritePreset(fileName)
+  for _, fav in ipairs(Props.favoritePresets) do
+    if fav == fileName then return true end
+  end
+  return false
+end
+
+function Props:ToggleFavoritePreset(preset)
+  for i, fav in ipairs(Props.favoritePresets) do
+    if fav == preset.file_name then
+      table.remove(Props.favoritePresets, i)
+      AMM:ExportUserData()
+      return
+    end
+  end
+  table.insert(Props.favoritePresets, preset.file_name)
+  AMM:ExportUserData()
 end
 
 function Props:DeletePreset(preset)

--- a/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/init.lua
+++ b/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/init.lua
@@ -2553,7 +2553,8 @@ function AMM:ImportUserData()
 				self.selectedLanguage = self:GetLanguageIndex(userData['selectedLanguage'] or "en_US")
 				self.UI.style.listScaleFactor = userData['listScaleFactor'] or 0
 				self.Props.presetTriggerDistance = userData['presetTriggerDistance'] or 60
-				self.Tools.favoriteExpressions = userData['favoriteExpressions'] or {}
+                                self.Tools.favoriteExpressions = userData['favoriteExpressions'] or {}
+                                self.Props.favoritePresets = userData['favoritePresets'] or {}
 
 				if userData['settings'] ~= nil then
 					for _, obj in ipairs(userData['settings']) do
@@ -2703,7 +2704,8 @@ function AMM:ExportUserData()
 		userData['selectedLanguage'] = self.availableLanguages[self.selectedLanguage].name or "en_US"
 		userData['listScaleFactor'] = self.UI.style.listScaleFactor
 		userData['presetTriggerDistance'] = self.Props.presetTriggerDistance
-		userData['favoriteExpressions'] = self.Tools.favoriteExpressions
+                userData['favoriteExpressions'] = self.Tools.favoriteExpressions
+                userData['favoritePresets'] = self.Props.favoritePresets
 
 		local validJson, contents = pcall(function() return json.encode(userData) end)
 		if validJson and contents ~= nil then


### PR DESCRIPTION
## Summary
- allow marking decor presets as favorites
- reorder preset dropdown so favorites come first
- save favorite presets in user.json

## Testing
- `lua -v` *(fails: command not found)*
- `luac -v` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848315eb1d08323b2599f171f3372cd