### PR TITLE
Fix unique spawn limit respect experimental

### DIFF
--- a/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/Modules/spawn.lua
+++ b/Release/bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceMenuMod/Modules/spawn.lua
@@ -306,18 +306,18 @@ function Spawn:DrawEntitiesButtons(entities, categoryName, style)
 			isFavorite = fav
 		end
 
-		if Spawn.spawnedNPCs[newSpawn.uniqueName()] and AMM:IsUnique(newSpawn.id) then
-			ImGui.PushStyleColor(ImGuiCol.Button, 0.56, 0.06, 0.03, 0.25)
-			ImGui.PushStyleColor(ImGuiCol.ButtonHovered, 0.56, 0.06, 0.03, 0.25)
-			ImGui.PushStyleColor(ImGuiCol.ButtonActive, 0.56, 0.06, 0.03, 0.25)
-			AMM:DrawButton(buttonLabel, -1 - favOffset, style.buttonHeight, "Disabled", nil)
-			ImGui.PopStyleColor(3)
-		elseif not(Spawn.spawnedNPCs[newSpawn.uniqueName()] ~= nil and AMM:IsUnique(newSpawn.id)) then
-			local action = "SpawnNPC"
-			if string.find(tostring(newSpawn.path), "Vehicle") then action = "SpawnVehicle" end
-			if string.find(tostring(newSpawn.path), "Props") then action = "SpawnProp" end
-			AMM:DrawButton(buttonLabel, -1 - favOffset, style.buttonHeight, action, newSpawn)
-		end
+                if not AMM.userSettings.experimental and Spawn.spawnedNPCs[newSpawn.uniqueName()] and AMM:IsUnique(newSpawn.id) then
+                        ImGui.PushStyleColor(ImGuiCol.Button, 0.56, 0.06, 0.03, 0.25)
+                        ImGui.PushStyleColor(ImGuiCol.ButtonHovered, 0.56, 0.06, 0.03, 0.25)
+                        ImGui.PushStyleColor(ImGuiCol.ButtonActive, 0.56, 0.06, 0.03, 0.25)
+                        AMM:DrawButton(buttonLabel, -1 - favOffset, style.buttonHeight, "Disabled", nil)
+                        ImGui.PopStyleColor(3)
+                else
+                        local action = "SpawnNPC"
+                        if string.find(tostring(newSpawn.path), "Vehicle") then action = "SpawnVehicle" end
+                        if string.find(tostring(newSpawn.path), "Props") then action = "SpawnProp" end
+                        AMM:DrawButton(buttonLabel, -1 - favOffset, style.buttonHeight, action, newSpawn)
+                end
 
 		if categoryName == 'Favorites' then
 			ImGui.SameLine()


### PR DESCRIPTION
## Summary
- adjust spawn logic so unique NPC restrictions only apply when experimental mode is off

## Testing
- `lua -v` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685abd0c79308323b6c0852c89a0880b